### PR TITLE
CoffeeScript on NPM has moved to "coffeescript  (no hyphen)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "call-delayed": "^1.0.0",
     "chai": "^3.5.0",
     "chai-increasing": "^1.2.0",
-    "coffee-script": "~1.12.2",
+    "coffeescript": "~2.3.1",
     "mocha": "~3.2.0",
     "pre-commit": "^1.2.2",
     "typescript": "^2.1.6"


### PR DESCRIPTION
Due to some deps you we get deprecation warnings about coffeescript and the hyphen in between.
Maybe we could also update to the newest coffeescript version :) 

Thanks in advance 
Oliver